### PR TITLE
Correct per-mollusc alpha export

### DIFF
--- a/src/mollex.cxx
+++ b/src/mollex.cxx
@@ -189,7 +189,6 @@ std::vector<cv::Mat> process(std::string imageName, std::string inDir) {
 		cv::Mat outImage;
 		cv::merge(channels, outImage);
 		auto segment = cv::Mat(outImage, boundingBox).clone();
-		cv::resize(segment, segment, cv::Size{ 256, 256 }, 1.0, 1.0, cv::INTER_AREA);
 		images.push_back(segment);
 	}
 	return images;

--- a/src/mollex.cxx
+++ b/src/mollex.cxx
@@ -16,6 +16,8 @@
 
 using contour = std::vector<cv::Point2i>;
 
+const int32_t downsampling_width = 256;
+
 #if !(__cplusplus >= 201703L)
 namespace std {
 template<typename T>
@@ -189,6 +191,8 @@ std::vector<cv::Mat> process(std::string imageName, std::string inDir) {
 		cv::Mat outImage;
 		cv::merge(channels, outImage);
 		auto segment = cv::Mat(outImage, boundingBox).clone();
+		const auto scale_factor = (boundingBox.size().width >= downsampling_width) ? downsampling_width/(double)boundingBox.size().width : 1.0;
+		cv::resize(segment, segment, cv::Size{}, scale_factor, scale_factor, cv::INTER_AREA);
 		images.push_back(segment);
 	}
 	return images;


### PR DESCRIPTION
Previously, we would use the same alpha mask for every mollusc,
meaning that if the bounding boxes of two molluscs intersected,
a tiny slice of another mollusc would be shown within the exported
image.
Furthermore, holes that the heuristic determined are not molluscs
were erroneously included in the exported alpha mask.

Both issues are fixed by exporting a per-contour alpha mask.

Furthermore, downsize the exported images since they are relatively large (> 1MB). Closes #9.