### PR TITLE
Calculate bounding boxes (including rotation and aspect ratio)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_executable(mollex mollex.cxx detect.cxx molluscoid.cxx)
 target_link_libraries(mollex ${OpenCV_LIBS} ${CMAKE_THREAD_LIBS_INIT})
-target_compile_definitions(mollex PRIVATE $<$<CONFIG:Debug>:DEBUG>)
+target_compile_definitions(mollex PRIVATE
+	$<$<CONFIG:Debug>:DEBUG>
+	$<IF:$<PLATFORM_ID:Windows>,_USE_MATH_DEFINES,>
+	)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(mollex mollex.cxx detect.cxx)
+add_executable(mollex mollex.cxx detect.cxx molluscoid.cxx)
 target_link_libraries(mollex ${OpenCV_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 target_compile_definitions(mollex PRIVATE $<$<CONFIG:Debug>:DEBUG>)

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <vector>
+
+#include <opencv/cv.h>
+
+using contour = std::vector<cv::Point2i>;
+
+

--- a/src/detect.cxx
+++ b/src/detect.cxx
@@ -10,6 +10,7 @@
 
 #include "tunables.h"
 
+#include "molluscoid.h"
 #include "detect.h"
 
 const int32_t downsampling_width = 256;
@@ -22,29 +23,6 @@ constexpr const T& clamp(const T& val, const T& min, const T& max) {
 }
 }
 #endif
-
-cv::RotatedRect normalize_rrect(cv::RotatedRect rr) {
-	if (rr.size.height > rr.size.width) {
-		rr.angle += 90;
-		std::swap(rr.size.height, rr.size.width);
-	}
-	return rr;
-}
-
-double molluscoid::ratio() const {
-	return bounding_rect.size.height/bounding_rect.size.width;
-}
-double molluscoid::angle() const {
-	return (bounding_rect.angle * M_PI) / 180;
-}
-
-molluscoid::molluscoid(const contour& _cont, const cv::Mat& _image) :
-	cont{_cont},
-	image{_image},
-	bounding_rect{normalize_rrect(cv::minAreaRect(cont))} {
-}
-
-molluscoid::~molluscoid() {}
 
 bool moldec::decide(const contour& cont) {
     const double area = cv::contourArea(cont);

--- a/src/detect.h
+++ b/src/detect.h
@@ -11,11 +11,24 @@ using contour = std::vector<cv::Point2i>;
 std::vector<cv::Mat> process(std::string imageName, std::string inDir);
 std::string getColor(cv::Mat image);
 
+struct molluscoid {
+	const contour cont;
+	const cv::Mat image;
+	const cv::RotatedRect bounding_rect;
+
+	std::string get_color() const;
+	double ratio() const;
+	double angle() const;
+	
+	molluscoid(const contour& _cont, const cv::Mat& _image);
+	~molluscoid();
+};
+
 class moldec {
 	const cv::Mat origin;
 	std::vector<contour> contours;
 	cv::Mat thresholded;
-	std::vector<cv::Mat> molluscoids;
+	std::vector<molluscoid> molluscoids;
 
 	void find_contours();
 	void extract_molluscoids();

--- a/src/detect.h
+++ b/src/detect.h
@@ -6,23 +6,8 @@
 
 #include <opencv/cv.h>
 
-using contour = std::vector<cv::Point2i>;
-
-std::vector<cv::Mat> process(std::string imageName, std::string inDir);
-std::string getColor(cv::Mat image);
-
-struct molluscoid {
-	const contour cont;
-	const cv::Mat image;
-	const cv::RotatedRect bounding_rect;
-
-	std::string get_color() const;
-	double ratio() const;
-	double angle() const;
-	
-	molluscoid(const contour& _cont, const cv::Mat& _image);
-	~molluscoid();
-};
+#include "molluscoid.h"
+#include "common.h"
 
 class moldec {
 	const cv::Mat origin;
@@ -45,3 +30,4 @@ public:
 
 	void write_images(std::ostream& os, const std::vector<std::string>& data, const std::string& imageName) const;
 };
+

--- a/src/detect.h
+++ b/src/detect.h
@@ -6,6 +6,29 @@
 
 #include <opencv/cv.h>
 
+using contour = std::vector<cv::Point2i>;
+
 std::vector<cv::Mat> process(std::string imageName, std::string inDir);
 std::string getColor(cv::Mat image);
 
+class moldec {
+	const cv::Mat origin;
+	std::vector<contour> contours;
+	cv::Mat thresholded;
+	std::vector<cv::Mat> molluscoids;
+
+	void find_contours();
+	void extract_molluscoids();
+	static bool decide(const contour& cont);
+	double determine_threshold(const cv::Mat&) const;
+	void threshold(const cv::Mat&);
+
+	std::string get_color(const cv::Mat& img) const;
+public:
+	moldec(const cv::Mat& img);
+	~moldec();
+
+	std::vector<contour> get_contours() const;
+
+	void write_images(std::ostream& os, const std::vector<std::string>& data, const std::string& imageName) const;
+};

--- a/src/mollex.cxx
+++ b/src/mollex.cxx
@@ -14,24 +14,11 @@
 #include <opencv/cv.hpp>
 
 void write_image(const std::string& imageName, const std::vector<std::string>& data, std::ostream& newMetaFile) {
-	const auto images = process(imageName, "images");
-	int i = 0;
-	for (auto image : images) {
-		const std::string fname { imageName + "_" + std::to_string(i) + ".png" };
-		cv::imwrite("data/" + fname, image);
-		newMetaFile << fname << ";";
-		newMetaFile << "#" << getColor(image) << ";";
-		newMetaFile << "0.0;";
-		newMetaFile << "1.0;";
-		newMetaFile << imageName << ".jpg";
-			
-		for (auto d : data) {
-			newMetaFile << ";" << d;
-		}
-		newMetaFile << std::endl;
+    const cv::Mat img = cv::imread("images/" + imageName + ".jpg");
+    if (!img.data) return;
+	const moldec md { img };
 
-		i++;
-	}
+	md.write_images(newMetaFile, data, imageName);
 }
 
 void process_line(const std::string& line, std::ostream& newMetaFile) {

--- a/src/molluscoid.cxx
+++ b/src/molluscoid.cxx
@@ -1,0 +1,37 @@
+#include <cmath>
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <fstream>
+
+#include <opencv/cv.hpp>
+
+#include "tunables.h"
+
+#include "molluscoid.h"
+
+cv::RotatedRect normalize_rrect(cv::RotatedRect rr) {
+	if (rr.size.height > rr.size.width) {
+		rr.angle += 90;
+		std::swap(rr.size.height, rr.size.width);
+	}
+	return rr;
+}
+
+double molluscoid::ratio() const {
+	return bounding_rect.size.height/bounding_rect.size.width;
+}
+double molluscoid::angle() const {
+	return (bounding_rect.angle * M_PI) / 180;
+}
+
+molluscoid::molluscoid(const contour& _cont, const cv::Mat& _image) :
+	cont{_cont},
+	image{_image},
+	bounding_rect{normalize_rrect(cv::minAreaRect(cont))} {
+}
+
+molluscoid::~molluscoid() {}
+

--- a/src/molluscoid.h
+++ b/src/molluscoid.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <opencv/cv.h>
+
+#include "common.h"
+
+struct molluscoid {
+	const contour cont;
+	const cv::Mat image;
+	const cv::RotatedRect bounding_rect;
+
+	std::string get_color() const;
+	double ratio() const;
+	double angle() const;
+	
+	molluscoid(const contour& _cont, const cv::Mat& _image);
+	~molluscoid();
+};
+


### PR DESCRIPTION
This PR includes some refactoring. The rather large mollusc detection code was reorganized into classes and some classes were moved to separate files.
This closes #12.